### PR TITLE
Added rescue blocks and check for status

### DIFF
--- a/hive-runner-android.gemspec
+++ b/hive-runner-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name	    	= 'hive-runner-android'
-  s.version	    	= '1.2.6'
+  s.version	    	= '1.2.7'
   s.date 	    	= Time.now.strftime("%Y-%m-%d")
   s.summary	    	= 'Hive Runner Android'
   s.description		= 'The Android controller module for Hive Runner'

--- a/lib/hive/controller/android.rb
+++ b/lib/hive/controller/android.rb
@@ -88,7 +88,7 @@ module Hive
            end
           rescue => e
            Hive.logger.debug("Connected Devices: #{connected_devices}")
-           Hive.logger.info(e)
+           Hive.logger.warn(e)
           end 
         end
         Hive.logger.info(attached_devices)

--- a/lib/hive/controller/android.rb
+++ b/lib/hive/controller/android.rb
@@ -35,7 +35,7 @@ module Hive
           begin
             registered_device = connected_devices.select { |a| a.serial == device['serial'] }
           rescue => e
-            registered_device = ""
+            registered_device = []
           end
           if registered_device.empty?
             # A previously registered device isn't attached
@@ -133,7 +133,7 @@ module Hive
         rescue => DeviceAPI::DeviceNotFound
            Hive.logger.info("Device disconnected while getting list of devices")
         rescue => e
-           Hive.logger.info("Device has got some issue. Exception => #{e}. Debug and connect device manually")
+           Hive.logger.warn("Device has got some issue. Exception => #{e}. Debug and connect device manually")
         end
       end
 


### PR DESCRIPTION
Depends on [device_api-android #117](https://github.com/bbc/device_api-android/pull/117/files) which checks for statuses offline and unknown 

Many times device is shown under 'adb devices' list, however while performing adb action on devices returns protocol fault status. This PR catches these exception and does not perform action on device. Later worker process is killed.