### PR TITLE
Update in diagnostic reporting

### DIFF
--- a/lib/hive/diagnostic/android/battery.rb
+++ b/lib/hive/diagnostic/android/battery.rb
@@ -10,7 +10,7 @@ module Hive
 
       def units
         {
-          :temperature => "K",
+          :temperature => "ºC",
           :voltage => "mV"
         }
       end
@@ -22,6 +22,7 @@ module Hive
         config.keys.each do |c| 
         raise InvalidParameterError.new("Battery Parameter should be any of #{battery_info.keys}") if !battery_info.has_key? c
           begin
+            battery_info[c] = battery_info[c].to_i/10 if c == "temperature"
             data[:"#{c}"] = { :value => battery_info[c], :unit => units[:"#{c}"] }
             result = "fail" if battery_info[c].to_i > config[c].to_i
           rescue => e

--- a/lib/hive/diagnostic/android/memory.rb
+++ b/lib/hive/diagnostic/android/memory.rb
@@ -18,7 +18,7 @@ module Hive
           operator = {:free => :>=, :used => :<= , :total => :==}
           memory_status = memory
           config.each do |key, value|
-            raise InvalidParameterError.new("Battery Parameter should be any of ':free', ':used', ':total'") if !memory_status.has_key? key
+            raise InvalidParameterError.new("Battery Parameter should be any of ':free', ':used', ':total'") if !memory_status.has_key? key.to_sym
             data[:"#{key}_memory"] = {:value => value, :unit => "kB"}
             result = "fail" if !memory_status[:"#{key}"].to_i.send(operator[:"#{key}"], value.to_i)
           end 

--- a/lib/hive/diagnostic/android/uptime.rb
+++ b/lib/hive/diagnostic/android/uptime.rb
@@ -22,9 +22,10 @@ module Hive
         def repair(result)
           data = {}
           Hive.logger.info("Rebooting the device")
-          begin  
-            self.device_api.reboot
+          begin
             data[:last_rebooted] = {:value => Time.now}
+            self.pass("Reboot", data)
+            self.device_api.reboot
           rescue
             Hive.logger.error("Device not found")
           end


### PR DESCRIPTION
1. Added symbol check in memory diagnostic which was failing
2. Battery diagnostic now reports correct temperature unit
3. Sometimes controller tries to access device when it is rebooting and when unable to do so it kills the worker process hence data is not recorded back in hivemind, hence passing data before reboot.